### PR TITLE
handle non-gzip pathnames in publish

### DIFF
--- a/lib/s3-publisher.rb
+++ b/lib/s3-publisher.rb
@@ -121,10 +121,13 @@ class S3Publisher
       begin
         gzip = item[:gzip] != false && !item[:write_opts][:content_type].match('image/')
 
+        if item[:contents].is_a?(Pathname)
+          item[:contents] = item[:contents].read
+        end
+
         if gzip
           item[:write_opts][:content_encoding] = 'gzip'
-          gzip_body = item[:contents].is_a?(Pathname) ? item[:contents].read : item[:contents]
-          item[:contents] = gzip(gzip_body)
+          item[:contents] = gzip(item[:contents])
         end
 
         write_opts = {

--- a/spec/s3_publisher_spec.rb
+++ b/spec/s3_publisher_spec.rb
@@ -42,7 +42,7 @@ describe S3Publisher do
     end
 
     describe ":file opt" do
-      it "queues files as a pathname to be read if gzip is false" do
+      it "queues contents of files if gzip is false" do
         set_put_expectation(file: __FILE__)
         push_test_data('myfile.txt', file: __FILE__, gzip: false)
       end
@@ -102,7 +102,7 @@ describe S3Publisher do
       if opts[:data]
         expected_contents = opts[:data]
       elsif opts[:file]
-        expected_contents = Pathname.new(opts[:file])
+        expected_contents = Pathname.new(opts[:file]).read
       else
         expected_contents = anything
       end


### PR DESCRIPTION
Should fix this error I'm getting when publishing files that don't need to be gzipped, like pngs.

```
remote: Wrote http://REDACTED.css with {:acl=>"public-read", :content_type=>"text/css", :cache_control=>"max-age=5", :content_encoding=>"gzip"}
remote: /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/aws-sdk-core/param_validator.rb:28:in `validate!': expected params[:body] to be a String or IO object, got value #<Pathname:public/REDACTED.png> (class: Pathname) instead. (ArgumentError)
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/aws-sdk-core/param_validator.rb:13:in `validate!'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/aws-sdk-core/plugins/param_validator.rb:20:in `call'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/aws-sdk-core/plugins/s3_sse_cpk.rb:19:in `call'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/aws-sdk-core/plugins/s3_accelerate.rb:33:in `call'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/aws-sdk-core/plugins/param_converter.rb:20:in `call'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/seahorse/client/plugins/response_target.rb:21:in `call'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/seahorse/client/request.rb:70:in `send_request'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/aws-sdk-core-2.5.2/lib/seahorse/client/base.rb:207:in `block (2 levels) in define_operation_methods'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/s3-publisher-2.0.0/lib/s3-publisher.rb:137:in `block in publish_from_queue'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/s3-publisher-2.0.0/lib/s3-publisher.rb:117:in `loop'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/s3-publisher-2.0.0/lib/s3-publisher.rb:117:in `publish_from_queue'
remote: 	from /mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/vendor/bundle/ruby/2.1.0/gems/s3-publisher-2.0.0/lib/s3-publisher.rb:96:in `block (2 levels) in run'
remote: Trace: Error: publish.rb failed: 1
remote:     at ChildProcess.<anonymous> (/mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/bin/publish:95:53)
remote:     at ChildProcess.emit (events.js:98:17)
remote:     at maybeClose (child_process.js:766:16)
remote:     at Process.ChildProcess._handle.onexit (child_process.js:833:5)
remote:     at child.spawn.stdio (/mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/bin/publish:61:26)
remote:     at notify (/mnt/var/git/apps/pipeline/node_modules/queue-async/queue.js:45:26)
remote:     at /mnt/var/git/apps/pipeline/node_modules/queue-async/queue.js:35:11
remote:     at ChildProcess.<anonymous> (/mnt/var/git/apps/pipeline/2e2a5d7857a5f32790ed0acf02cd1aae4f1632cb/bin/publish:95:5)
remote:     at ChildProcess.emit (events.js:98:17)
remote:     at maybeClose (child_process.js:766:16)
remote:     at Process.ChildProcess._handle.onexit (child_process.js:833:5)
remote: 10 Aug 15:13:21 - rm -rf -- /tmp/REDACTED@555c7a3dbdd6db908ca6d8fe119984615ffde3a6
```